### PR TITLE
Build on older ghcs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: haskell
 
-env:
-  - 'UBUNTU_RELEASE=saucy'
-  - 'UBUNTU_RELEASE=trusty'
-
-before_install:
-  - 'sudo apt-get install cabal-install ghc happy'
+ghc:
+  - 7.4
+  - 7.6
+  - 7.8
 
 install:
   - 'cabal update'

--- a/nagios-perfdata.cabal
+++ b/nagios-perfdata.cabal
@@ -3,7 +3,7 @@ version:             0.2.1
 synopsis:            Parse Nagios performance data.
 description:         Provides an interface for parsing Nagios
                      performance data formatted according to the plugin
-                     development guidelines. 
+                     development guidelines.
 homepage:            https://github.com/anchor/nagios-perfdata
 license:             BSD3
 license-file:        LICENSE
@@ -27,8 +27,8 @@ library
                      Data.Nagios.Perfdata.Error,
                      Data.Nagios.Perfdata.GearmanResult,
                      Data.Nagios.Perfdata.Template
-  build-depends:     base >=4.6 && <= 5,
-                     bytestring, 
+  build-depends:     base >=4.5 && <= 5,
+                     bytestring,
                      mtl,
                      containers,
                      attoparsec,
@@ -45,7 +45,7 @@ test-suite           perfdata-test
   type:              exitcode-stdio-1.0
   default-language:  Haskell2010
 
-  build-depends:     base >=4.6,
+  build-depends:     base >=4.5 && <= 5,
                      hspec,
                      bytestring,
                      nagios-perfdata,


### PR DESCRIPTION
By loosening the constraint on base, this program can build on GHC 7.4. Currently this constraint is limiting upstream dependencies like [nagios-check](https://github.com/fractalcat/nagios-check) and other monitoring libraries using nagios-check, like one that I'm currently writing.

I modified the .travis.yml to also test on GHC 7.4.